### PR TITLE
chore: add new pr workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,7 @@
+<!--
+
+1. Prefix the title of the PR with either 'fix:' or  'feat:', depending on if the fix is a minor or major version.
+   - see: https://www.conventionalcommits.org/en/v1.0.0/
+2. Pull Request title format: `fix: <the-description>`, or `feat: <the-description>`
+3. Please ensure that the PR has the ticket ID and a detailed description of the changes.
+   For breaking changes, add a `BREAKING CHANGE: <description>` in the detailed description.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 
-on:
-  pull_request:
-    types: [opened, edited, synchronize, reopened, converted_to_draft, ready_for_review]
+on: [push]
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
-on: [push]
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, converted_to_draft, ready_for_review]
 
 jobs:
   release:
@@ -49,4 +51,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm run release
+          npm run canary-release

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,9 +1,11 @@
 # Validates the semantic release title for PRs
 # https://github.com/marketplace/actions/semantic-pull-request
 name: PR Title Check for Semantic Release
+
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened, converted_to_draft, ready_for_review]
+
 jobs:
   main:
     name: Validate Semantic Release PR title

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,14 @@
+# Validates the semantic release title for PRs
+# https://github.com/marketplace/actions/semantic-pull-request
+name: PR Title Check for Semantic Release
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, converted_to_draft, ready_for_review]
+jobs:
+  main:
+    name: Validate Semantic Release PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "run-p build:watch 'storybook --quiet'",
     "prerelease": "zx scripts/prepublish-checks.js",
-    "release": "npm run build && auto shipit",
+    "release": "npm run build",
+    "canary-release": "npm run release && auto shipit",
     "eject-ts": "zx scripts/eject-typescript.js",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/src/withHTML.ts
+++ b/src/withHTML.ts
@@ -38,6 +38,8 @@ export const withHTML = makeDecorator({
 
       let code = litElement;
 
+      console.log("code: %o ", code);
+
       const { removeEmptyComments = true, removeComments = true, transform } = parameters;
       if (removeEmptyComments) {
         code = code.replace(/<!--\s*-->/g, "");


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.6--canary.3.e973811.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @thecaffeinateddev/storybook-addon-web-component-html@0.0.6--canary.3.e973811.0
  # or 
  yarn add @thecaffeinateddev/storybook-addon-web-component-html@0.0.6--canary.3.e973811.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
